### PR TITLE
fixed header image for iphone

### DIFF
--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -197,7 +197,7 @@ const Header = styled(`header`)(({ theme }) => ({
   background: `url("./stridewars_reduced.jpg")`,
   backgroundSize: "cover",
   backgroundRepeat: "no-repeat",
-  backgroundAttachment: "fixed",
+  backgroundAttachment: "scroll",
   display: "flex",
   flexDirection: "column",
   alignItems: "center",
@@ -207,6 +207,7 @@ const Header = styled(`header`)(({ theme }) => ({
   "&::before": {
     backgroundColor: theme.palette.common.black,
     opacity: 0.8,
+    height: "100vh",
     position: "absolute",
     top: 0,
     bottom: 0,


### PR DESCRIPTION
iPhone doesn't play well with 

  backgroundSize: "cover",
  backgroundAttachment: “fixed”,
  
Switched it to "scroll" but you do lose the fancy scrolling.
I imagine it's possible to only do this for iPads or iPhone?   

This guy has done it with JS:
https://stackoverflow.com/a/20444219/1935307